### PR TITLE
XP Command Update to allow re-inviting DCd members to locked fellowships.

### DIFF
--- a/Source/ACE.Server/Entity/Fellowship.cs
+++ b/Source/ACE.Server/Entity/Fellowship.cs
@@ -84,7 +84,7 @@ namespace ACE.Server.Entity
                 if (!DepartedMembers.TryGetValue(newMember.Guid.Full, out var timeDeparted))
                 {
                     inviter.Session.Network.EnqueueSend(new GameEventWeenieErrorWithString(inviter.Session, WeenieErrorWithString.LockedFellowshipCannotRecruit_, newMember.Name));
-                    //newMember.SendWeenieError(WeenieError.LockedFellowshipCannotRecruitYou);
+                    newMember.Session.Network.EnqueueSend(new GameMessageSystemChat($"Cannot add to locked fellowship. You were not an original member.", ChatMessageType.Broadcast));
                     return;
                 }
                 else
@@ -93,7 +93,7 @@ namespace ACE.Server.Entity
                     if (DateTime.UtcNow > timeLimit)
                     {
                         inviter.Session.Network.EnqueueSend(new GameEventWeenieErrorWithString(inviter.Session, WeenieErrorWithString.LockedFellowshipCannotRecruit_, newMember.Name));
-                        //newMember.SendWeenieError(WeenieError.LockedFellowshipCannotRecruitYou);
+                        newMember.Session.Network.EnqueueSend(new GameMessageSystemChat($"Cannot add to locked fellowship. The 10 minute grace period to rejoin as elapsed.", ChatMessageType.Broadcast));
                         return;
                     }
                 }
@@ -102,12 +102,14 @@ namespace ACE.Server.Entity
             if (FellowshipMembers.Count >= MaxFellows)
             {
                 inviter.Session.Network.EnqueueSend(new GameEventWeenieError(inviter.Session, WeenieError.YourFellowshipIsFull));
+                newMember.Session.Network.EnqueueSend(new GameMessageSystemChat($"Cannot add to fellowship. The fellowship is already full.", ChatMessageType.Broadcast));
                 return;
             }
 
             if (newMember.Fellowship != null || FellowshipMembers.ContainsKey(newMember.Guid.Full))
             {
                 inviter.Session.Network.EnqueueSend(new GameMessageSystemChat($"{newMember.Name} is already a member of a Fellowship.", ChatMessageType.Broadcast));
+                newMember.Session.Network.EnqueueSend(new GameMessageSystemChat($"You are already a member of a fellowship.", ChatMessageType.Broadcast));
             }
             else
             {

--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionTalkDirect.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionTalkDirect.cs
@@ -43,13 +43,18 @@ namespace ACE.Server.Network.GameAction.Actions
                     return;
                 }
 
-                if (message.Equals("xp", System.StringComparison.OrdinalIgnoreCase) && targetPlayer.Fellowship != null && targetPlayer.Fellowship.Open)
+                if (message.Equals("xp", System.StringComparison.OrdinalIgnoreCase))
                 {
+                    if (targetPlayer.Fellowship == null)
+                    {
+                        session.Network.EnqueueSend(new GameMessageSystemChat($"[FSHIP]: Cannot add to fellowship. {targetPlayer.Name} is not part of a fellowship.", ChatMessageType.Broadcast));
+                        return;
+                    }
+
                     session.Network.EnqueueSend(new GameMessageSystemChat($"[FSHIP]: Attempting to add you to {targetPlayer.Name}'s fellowship.", ChatMessageType.Broadcast));
                     targetPlayer.FellowshipRecruit(session.Player);
                     return;
                 }
-
 
                 var tell = new GameEventTell(targetPlayer.Session, message, session.Player.GetNameWithSuffix(), session.Player.Guid.Full, targetPlayer.Guid.Full, ChatMessageType.Tell);
                 targetPlayer.Session.Network.EnqueueSend(tell);

--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionTell.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionTell.cs
@@ -49,8 +49,14 @@ namespace ACE.Server.Network.GameAction.Actions
                 //return;
             }
 
-            if (message.Equals("xp", System.StringComparison.OrdinalIgnoreCase) && targetPlayer.Fellowship != null && targetPlayer.Fellowship.Open)
+            if (message.Equals("xp", System.StringComparison.OrdinalIgnoreCase))
             {
+                if (targetPlayer.Fellowship == null)
+                {
+                    session.Network.EnqueueSend(new GameMessageSystemChat($"[FSHIP]: Cannot add to fellowship. {targetPlayer.Name} is not part of a fellowship.", ChatMessageType.Broadcast));
+                    return;
+                }
+
                 session.Network.EnqueueSend(new GameMessageSystemChat($"[FSHIP]: Attempting to add you to {targetPlayer.Name}'s fellowship.", ChatMessageType.Broadcast));
                 targetPlayer.FellowshipRecruit(session.Player);
                 return;

--- a/Source/ACE.Server/WorldObjects/Player_Fellowship.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Fellowship.cs
@@ -1,6 +1,7 @@
 using ACE.Entity.Enum;
 using ACE.Server.Entity;
 using ACE.Server.Managers;
+using ACE.Server.Network;
 using ACE.Server.Network.GameEvent.Events;
 using ACE.Server.Network.GameMessages.Messages;
 
@@ -99,13 +100,17 @@ namespace ACE.Server.WorldObjects
             {
                 Session.Network.EnqueueSend(new GameMessageSystemChat($"{newPlayer.Name} is not accepting fellowship requests.", ChatMessageType.Fellowship));                
                 Session.Network.EnqueueSend(new GameEventWeenieError(Session, WeenieError.FellowshipIgnoringRequests));
+                newPlayer.Session.Network.EnqueueSend(new GameMessageSystemChat($"[FSHIP]: Cannot add to fellowship. You are ignoring fellowship requests.", ChatMessageType.Broadcast));
             }
             else if (Fellowship != null)
             {
                 if (Guid.Full == Fellowship.FellowshipLeaderGuid || Fellowship.Open)
                     Fellowship.AddFellowshipMember(this, newPlayer);
                 else
+                {
                     Session.Network.EnqueueSend(new GameEventWeenieError(Session, WeenieError.YouMustBeLeaderOfFellowship));
+                    newPlayer.Session.Network.EnqueueSend(new GameMessageSystemChat($"[FSHIP]: Cannot add to fellowship. {Name}'s fellowship is not open.", ChatMessageType.Broadcast));
+                }
             }
         }
 


### PR DESCRIPTION
Updated "xp" message command. No longer requires open fellowship type to execute -- uses the existing fellowship recruitment system. This should allow the command to reinvite DCd members to a locked fellow when over 9 players.

Send failure messages to the person being recruited as well so they know why the command didn't work.